### PR TITLE
adding rubygems.org as source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+source 'http://rubygems.org'
+
 gem 'flay-js'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'flay-js'
 


### PR DESCRIPTION
'bundle install' fails with the following error if the gem is not present on the machine.

```
Your Gemfile has no gem server sources. If you need gems that are not already on
your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find gem 'flay-js (>= 0) ruby' in any of the gem sources listed in your
Gemfile or installed on this machine.
```
